### PR TITLE
Fix demo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use `quasar describe QFlashcard` or `quasar describe QFlashcardSection`
 In **demo** folder of **app-extension-qflashcard**.
 
 # Demo
-Can be found [here](https://quasarframework.github.io/app-extension-qflashcard/demo/dist/spa/#/).
+Can be found [here](https://quasarframework.github.io/app-extension-qflashcard/).
 
 # Example Code
 This example mashes up the **nudge-in**, **fade-in**, and **slide-up-in** transitions.


### PR DESCRIPTION
The description was fixed after [this comment](https://github.com/quasarframework/app-extension-qpdfviewer/issues/1#issuecomment-503005403), but I noticed that the link in README is still broken. This PR aims to fix it.